### PR TITLE
Add per-component HSV control

### DIFF
--- a/light_control.py
+++ b/light_control.py
@@ -14,6 +14,9 @@ def usage():
     print("Usage:")
     print("  python light_control.py <device> <on|off>")
     print("  python light_control.py <device> hsv <hue> <sat> <val>")
+    print("  python light_control.py <device> h <hue>")
+    print("  python light_control.py <device> s <sat>")
+    print("  python light_control.py <device> v <val>")
     print("  python light_control.py <device> temp <kelvin>")
     print("  python light_control.py <device> bright <0-100>")
     print("  python light_control.py <device> get")
@@ -43,6 +46,32 @@ def get_device(name):
     except Exception:
         pass
     return dev
+
+
+def current_rgb(device):
+    """Return the current RGB tuple for *device*.
+
+    This tries to parse colour information from the device status in a
+    format compatible with :func:`set_colour`. Only the first three bytes
+    of any hex string are used if the exact layout is unknown.
+    """
+    status = device.status().get('dps', {})
+    colour = None
+    for key in ("colour", "color", "colour_data", "24", 24):
+        if key in status:
+            colour = status[key]
+            break
+    if isinstance(colour, dict):
+        r, g, b = (colour.get(k, 0) for k in ("r", "g", "b"))
+        return int(r), int(g), int(b)
+    if isinstance(colour, str) and len(colour) >= 6:
+        hexstr = colour.lstrip('#').replace(' ', '')
+        return (
+            int(hexstr[0:2], 16),
+            int(hexstr[2:4], 16),
+            int(hexstr[4:6], 16),
+        )
+    raise ValueError("Unable to determine current colour")
 
 
 def global_action(func):
@@ -90,6 +119,22 @@ if __name__ == '__main__':
         r, g, b = colorsys.hsv_to_rgb(h/360, s/100, v/100)
         device.set_colour(int(r*255), int(g*255), int(b*255))
         print(f"{name} HSV({h},{s},{v})")
+
+    elif action in ('h', 'hue', 's', 'sat', 'v', 'val'):
+        if len(sys.argv) != 4:
+            usage()
+        new_val = int(sys.argv[3])
+        r, g, b = current_rgb(device)
+        h, s, v = colorsys.rgb_to_hsv(r/255, g/255, b/255)
+        if action in ('h', 'hue'):
+            h = new_val / 360
+        elif action in ('s', 'sat'):
+            s = new_val / 100
+        else:
+            v = new_val / 100
+        r, g, b = colorsys.hsv_to_rgb(h, s, v)
+        device.set_colour(int(r*255), int(g*255), int(b*255))
+        print(f"{name} HSV({int(h*360)},{int(s*100)},{int(v*100)})")
 
     elif action == 'temp':
         if len(sys.argv) != 4:


### PR DESCRIPTION
## Summary
- expand command usage details
- parse current RGB values from device status
- add `h`, `s`, and `v` actions to modify HSV components in isolation

## Testing
- `python -m py_compile devices.py light_control.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa37795048325bbbd84fc2dd4af9f