### PR TITLE
Add preset save and load support

### DIFF
--- a/light_control.py
+++ b/light_control.py
@@ -20,6 +20,8 @@ def usage():
     print("  python light_control.py <device> temp <kelvin>")
     print("  python light_control.py <device> bright <0-100>")
     print("  python light_control.py <device> get")
+    print("  python light_control.py save_preset <name>")
+    print("  python light_control.py load_preset <name>")
     print("  python light_control.py all_on | allon | all_off | alloff")
     sys.exit(1)
 
@@ -120,11 +122,112 @@ def global_action(func):
     sys.exit(0)
 
 
+def _find_key(status, keys):
+    """Return the first entry in *keys* present in *status*."""
+    for key in keys:
+        if key in status:
+            return key
+        if isinstance(key, int) and str(key) in status:
+            return str(key)
+    return None
+
+
+def get_all_states():
+    """Return the current state of all configured devices."""
+
+    states = {}
+    for name, cfg in devices.items():
+        dev = get_device(name)
+        dps = dev.status().get('dps', {})
+        state = {}
+        key = _find_key(dps, ('switch', '1', 20))
+        if key is not None:
+            state['on'] = dps[key]
+        if cfg['type'] == 'bulb':
+            mode_key = _find_key(dps, ('mode', 21))
+            mode = dps.get(mode_key, 'colour')
+            state['mode'] = mode
+            if mode in ('colour', 'color'):
+                col_key = _find_key(dps, ('colour', 'color', 'colour_data',
+                                         'color_data', 24))
+                if col_key is not None:
+                    state['color'] = dps[col_key]
+                val_key = _find_key(dps, ('bright', 'brightness', 25))
+                if val_key is not None:
+                    state['value'] = dps[val_key]
+            else:  # assume white mode
+                bright_key = _find_key(dps, ('bright', 'brightness', 25))
+                if bright_key is not None:
+                    state['brightness'] = dps[bright_key]
+                temp_key = _find_key(dps, ('temp', 'colourtemp', 'color_temp',
+                                          26))
+                if temp_key is not None:
+                    state['temp'] = dps[temp_key]
+        states[name] = state
+    return states
+
+
+def save_preset(name):
+    """Save the current state of all devices to *name*.json."""
+
+    import json
+
+    states = get_all_states()
+    filename = f"{name}.json"
+    with open(filename, 'w') as fh:
+        json.dump(states, fh)
+    print(f"Saved preset to {filename}")
+
+
+def load_preset(name):
+    """Load the preset stored in *name*.json and apply it."""
+
+    import json
+
+    filename = f"{name}.json"
+    with open(filename) as fh:
+        states = json.load(fh)
+
+    for dev_name, state in states.items():
+        if dev_name not in devices:
+            continue
+        cfg = devices[dev_name]
+        dev = get_device(dev_name)
+        if 'on' in state:
+            (dev.turn_on if state['on'] else dev.turn_off)()
+        if cfg['type'] == 'bulb':
+            mode = state.get('mode')
+            if mode in ('colour', 'color'):
+                colour = state.get('color')
+                if isinstance(colour, str):
+                    hexstr = colour.lstrip('#')
+                    if len(hexstr) >= 6:
+                        r = int(hexstr[0:2], 16)
+                        g = int(hexstr[2:4], 16)
+                        b = int(hexstr[4:6], 16)
+                        dev.set_colour(r, g, b)
+                if 'value' in state and hasattr(dev, 'set_brightness'):
+                    dev.set_brightness(state['value'])
+            else:
+                if 'brightness' in state and hasattr(dev, 'set_brightness'):
+                    dev.set_brightness(state['brightness'])
+                if 'temp' in state:
+                    dev.set_colourtemp(state['temp'])
+
+
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         usage()
 
     cmd = sys.argv[1].lower()
+
+    if cmd == 'save_preset' and len(sys.argv) == 3:
+        save_preset(sys.argv[2])
+        sys.exit(0)
+
+    if cmd == 'load_preset' and len(sys.argv) == 3:
+        load_preset(sys.argv[2])
+        sys.exit(0)
 
     if cmd in ('all_on', 'allon', 'alloff', 'all_off'):
         action = 'turn_on' if 'on' in cmd else 'turn_off'

--- a/test_light_control.py
+++ b/test_light_control.py
@@ -1,4 +1,5 @@
 import colorsys
+import json
 import pytest
 import sys
 import types
@@ -24,6 +25,45 @@ class DummyDevice:
         self.colour_set = (r, g, b)
 
 
+class DummyBulb:
+    def __init__(self, status):
+        self._status = {'dps': status}
+        self.calls = []
+
+    def status(self):
+        return self._status
+
+    def turn_on(self):
+        self.calls.append('on')
+
+    def turn_off(self):
+        self.calls.append('off')
+
+    def set_colour(self, r, g, b):
+        self.calls.append(('colour', r, g, b))
+
+    def set_brightness(self, b):
+        self.calls.append(('brightness', b))
+
+    def set_colourtemp(self, t):
+        self.calls.append(('temp', t))
+
+
+class DummyPlug:
+    def __init__(self, status):
+        self._status = {'dps': status}
+        self.calls = []
+
+    def status(self):
+        return self._status
+
+    def turn_on(self):
+        self.calls.append('on')
+
+    def turn_off(self):
+        self.calls.append('off')
+
+
 def test_current_hsv_color_data():
     dev = DummyDevice('#00b401f403e8')
     h, s, v = light_control.current_hsv(dev)
@@ -39,3 +79,79 @@ def test_saturation_update_color_data():
     r, g, b = colorsys.hsv_to_rgb(h, new_s, v)
     dev.set_colour(int(r * 255), int(g * 255), int(b * 255))
     assert dev.colour_set == (int(r * 255), int(g * 255), int(b * 255))
+
+
+def test_get_all_states(monkeypatch):
+    bulb = DummyBulb({'20': True, '21': 'colour', '24': '#ff0000', '25': 80})
+    plug = DummyPlug({'1': False})
+
+    devices = {
+        'Bulb': {'type': 'bulb'},
+        'Plug': {'type': 'plug'},
+    }
+
+    def get_device(name):
+        return bulb if name == 'Bulb' else plug
+
+    monkeypatch.setattr(light_control, 'devices', devices)
+    monkeypatch.setattr(light_control, 'get_device', get_device)
+
+    states = light_control.get_all_states()
+    assert states == {
+        'Bulb': {
+            'on': True,
+            'mode': 'colour',
+            'color': '#ff0000',
+            'value': 80
+        },
+        'Plug': {'on': False},
+    }
+
+
+def test_save_and_load_preset(tmp_path, monkeypatch):
+    bulb = DummyBulb({'20': False, '21': 'colour', '24': '#00ff00', '25': 40})
+    plug = DummyPlug({'1': True})
+
+    devices = {'Bulb': {'type': 'bulb'}, 'Plug': {'type': 'plug'}}
+
+    def get_device(name):
+        return bulb if name == 'Bulb' else plug
+
+    monkeypatch.setattr(light_control, 'devices', devices)
+    monkeypatch.setattr(light_control, 'get_device', get_device)
+
+    preset_name = str(tmp_path / 'preset')
+
+    monkeypatch.setattr(
+        light_control,
+        'get_all_states',
+        lambda: {
+            'Bulb': {
+                'on': True,
+                'mode': 'colour',
+                'color': '#0000ff',
+                'value': 75
+            },
+            'Plug': {'on': False},
+        },
+    )
+
+    light_control.save_preset(preset_name)
+
+    with open(preset_name + '.json') as fh:
+        data = json.load(fh)
+
+    assert data['Bulb']['color'] == '#0000ff'
+    assert data['Plug']['on'] is False
+
+    # prepare for load
+    bulb.calls.clear()
+    plug.calls.clear()
+
+    light_control.load_preset(preset_name)
+
+    assert 'off' in plug.calls  # plug turned off
+    assert 'on' in bulb.calls  # bulb turned on from preset
+    assert ('colour', 0, 0, 255) in bulb.calls
+    assert ('brightness', 75) in bulb.calls
+


### PR DESCRIPTION
## Summary
- extend CLI usage for presets
- add helper functions to capture device states and save/load presets
- implement `save_preset` and `load_preset` CLI commands
- test preset functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb8cd8e8c8325ad89c96746a98d38