### PR TITLE
Fix preset color brightness parsing

### DIFF
--- a/test_light_control.py
+++ b/test_light_control.py
@@ -166,3 +166,28 @@ def test_save_and_load_preset(tmp_path, monkeypatch):
     assert 'on' in bulb.calls  # bulb turned on from preset
     assert ('colour', 0, 0, 255) in bulb.calls
     assert ('brightness', 50) in bulb.calls
+
+
+def test_load_preset_uses_hex_brightness(tmp_path, monkeypatch):
+    bulb = DummyBulb({'20': True})
+    devices = {'Bulb': {'type': 'bulb'}}
+
+    monkeypatch.setattr(light_control, 'devices', devices)
+    monkeypatch.setattr(light_control, 'get_device', lambda n: bulb)
+
+    preset = {
+        'Bulb': {
+            'on': True,
+            'mode': 'colour',
+            'color': '016203e803e8',
+            'value': 0,
+        }
+    }
+    preset_name = str(tmp_path / 'preset')
+    with open(preset_name + '.json', 'w') as fh:
+        json.dump(preset, fh)
+
+    light_control.load_preset(preset_name)
+
+    assert ('colour', 255, 0, 25) in bulb.calls
+    assert ('brightness', 100) in bulb.calls


### PR DESCRIPTION
## Summary
- parse brightness correctly from colour strings when loading presets
- default to brightness from colour string if preset value is zero
- coerce integer brightness values
- add tests for 12-digit colour strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fce002b748325b1ec9f24f4e59a16