### PR TITLE
Handle brightness in colour hex

### DIFF
--- a/light_control.py
+++ b/light_control.py
@@ -215,13 +215,23 @@ def get_all_states():
             mode = dps.get(mode_key, 'colour')
             state['mode'] = mode
             if mode in ('colour', 'color'):
-                col_key = _find_key(dps, ('colour', 'color', 'colour_data',
-                                         'color_data', 24))
+                col_key = _find_key(dps, (
+                    'colour', 'color', 'colour_data', 'color_data', 24
+                ))
+                parsed_val = None
                 if col_key is not None:
-                    state['color'] = dps[col_key]
+                    colour_val = dps[col_key]
+                    state['color'] = colour_val
+                    _, _, _, parsed_val = _parse_colour_str(colour_val)
+
                 val_key = _find_key(dps, ('bright', 'brightness', 'value', 25))
                 if val_key is not None:
-                    state['value'] = _coerce_level(dps[val_key])
+                    val = _coerce_level(dps[val_key])
+                    if val == 0 and parsed_val is not None:
+                        val = parsed_val
+                    state['value'] = val
+                elif parsed_val is not None:
+                    state['value'] = parsed_val
             else:  # assume white mode
                 bright_key = _find_key(dps, ('bright', 'brightness', 'value', 25))
                 if bright_key is not None:

--- a/test_light_control.py
+++ b/test_light_control.py
@@ -193,6 +193,23 @@ def test_load_preset_uses_hex_brightness(tmp_path, monkeypatch):
     assert ('brightness', 100) in bulb.calls
 
 
+def test_get_all_states_uses_hex_brightness(monkeypatch):
+    bulb = DummyBulb({
+        '20': True,
+        '21': 'colour',
+        'colour_data': '016203e803e8',
+        '25': '0',
+    })
+    devices = {'Bulb': {'type': 'bulb'}}
+
+    monkeypatch.setattr(light_control, 'devices', devices)
+    monkeypatch.setattr(light_control, 'get_device', lambda n: bulb)
+
+    states = light_control.get_all_states()
+    assert states['Bulb']['color'] == '016203e803e8'
+    assert states['Bulb']['value'] == 100
+
+
 def test_brightness_key_named_value(tmp_path, monkeypatch):
     bulb = DummyBulb({'20': False, '21': 'colour', '24': '#00ff00', 'value': '40'})
     plug = DummyPlug({'1': True})


### PR DESCRIPTION
## Summary
- detect brightness encoded in `colour_data` when retrieving states
- test brightness extraction from hex values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd3eb27bc83259f38281261b3d0d2