### PR TITLE
Add debug output for color handling

### DIFF
--- a/light_control.py
+++ b/light_control.py
@@ -66,6 +66,7 @@ def current_hsv(device):
     """
 
     status = device.status().get('dps', {})
+    print(f"[DEBUG] Device status dps: {status}")
     colour = None
     for key in ("colour", "color", "colour_data", "color_data", "24", 24):
         if key in status:
@@ -87,10 +88,13 @@ def current_hsv(device):
                     s /= 1000.0
                 if v > 1:
                     v /= 1000.0
+                print(f"[DEBUG] current_hsv HSV dict -> h:{h}, s:{s}, v:{v}")
                 return h, s, v
 
         r, g, b = (int(colour.get(k, 0)) for k in ("r", "g", "b"))
-        return colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+        h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+        print(f"[DEBUG] current_hsv RGB dict {r,g,b} -> h:{h}, s:{s}, v:{v}")
+        return h, s, v
 
     if isinstance(colour, str):
         hexstr = colour.lstrip('#').replace(' ', '')
@@ -100,6 +104,7 @@ def current_hsv(device):
                 h = int(hexstr[0:4], 16) / 360.0
                 s = int(hexstr[4:8], 16) / 1000.0
                 v = int(hexstr[8:12], 16) / 1000.0
+                print(f"[DEBUG] current_hsv HSV hex {hexstr} -> h:{h}, s:{s}, v:{v}")
                 return h, s, v
             except ValueError:
                 pass
@@ -107,7 +112,9 @@ def current_hsv(device):
             r = int(hexstr[0:2], 16)
             g = int(hexstr[2:4], 16)
             b = int(hexstr[4:6], 16)
-            return colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+            h, s, v = colorsys.rgb_to_hsv(r / 255, g / 255, b / 255)
+            print(f"[DEBUG] current_hsv RGB hex {hexstr} -> h:{h}, s:{s}, v:{v}")
+            return h, s, v
 
     raise ValueError("Unable to determine current colour")
 
@@ -116,7 +123,9 @@ def current_rgb(device):
     """Return the current RGB tuple for *device*."""
     h, s, v = current_hsv(device)
     r, g, b = colorsys.hsv_to_rgb(h, s, v)
-    return int(r * 255), int(g * 255), int(b * 255)
+    rgb = int(r * 255), int(g * 255), int(b * 255)
+    print(f"[DEBUG] current_rgb -> {rgb}")
+    return rgb
 
 
 def global_action(func):
@@ -183,7 +192,9 @@ def _parse_colour_str(colour):
             s = int(hexstr[4:8], 16) / 1000.0
             v = int(hexstr[8:12], 16)
             r, g, b = colorsys.hsv_to_rgb(h, s, v / 1000.0)
-            return int(r * 255), int(g * 255), int(b * 255), _coerce_level(v)
+            result = int(r * 255), int(g * 255), int(b * 255), _coerce_level(v)
+            print(f"[DEBUG] _parse_colour_str HSV hex {hexstr} -> {result}")
+            return result
         except ValueError:
             pass
 
@@ -192,10 +203,13 @@ def _parse_colour_str(colour):
             r = int(hexstr[0:2], 16)
             g = int(hexstr[2:4], 16)
             b = int(hexstr[4:6], 16)
-            return r, g, b, None
+            result = (r, g, b, None)
+            print(f"[DEBUG] _parse_colour_str RGB hex {hexstr} -> {result}")
+            return result
         except ValueError:
             pass
 
+    print(f"[DEBUG] _parse_colour_str failed to parse '{colour}'")
     return None, None, None, None
 
 
@@ -250,6 +264,7 @@ def save_preset(name):
     import json
 
     states = get_all_states()
+    print(f"[DEBUG] Preset states gathered: {states}")
     for state in states.values():
         if 'value' in state:
             state['value'] = _coerce_level(state['value'])
@@ -258,7 +273,7 @@ def save_preset(name):
     filename = f"{name}.json"
     with open(filename, 'w') as fh:
         json.dump(states, fh)
-    print(f"Saved preset to {filename}")
+    print(f"[DEBUG] Saved preset to {filename}")
 
 
 def load_preset(name):
@@ -269,8 +284,10 @@ def load_preset(name):
     filename = f"{name}.json"
     with open(filename) as fh:
         states = json.load(fh)
+    print(f"[DEBUG] Loaded preset from {filename}: {states}")
 
     for dev_name, state in states.items():
+        print(f"[DEBUG] Applying state for {dev_name}: {state}")
         if dev_name not in devices:
             continue
         cfg = devices[dev_name]
@@ -285,6 +302,7 @@ def load_preset(name):
                 colour = state.get('color')
                 r, g, b, default_val = _parse_colour_str(colour)
                 if r is not None:
+                    print(f"[DEBUG] Loading colour {r,g,b} on {dev_name}")
                     dev.set_colour(r, g, b)
                 if hasattr(dev, 'set_brightness'):
                     if 'value' in state:
@@ -294,12 +312,15 @@ def load_preset(name):
                     else:
                         val = default_val
                     if val is not None:
+                        print(f"[DEBUG] Loading brightness {val} on {dev_name}")
                         dev.set_brightness(val)
             else:
                 if 'brightness' in state and hasattr(dev, 'set_brightness'):
                     bright = _coerce_level(state['brightness'])
+                    print(f"[DEBUG] Loading brightness {bright} on {dev_name}")
                     dev.set_brightness(bright)
                 if 'temp' in state:
+                    print(f"[DEBUG] Loading colour temperature {state['temp']} on {dev_name}")
                     dev.set_colourtemp(state['temp'])
 
 


### PR DESCRIPTION
## Summary
- print debug info when retrieving bulb colour
- show conversions when parsing colour strings
- print states when saving and loading presets
- show colour and brightness applied when loading a preset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdc126c888325931681b28c45be3c