### PR TITLE
Improve preset loading speed

### DIFF
--- a/light_control.py
+++ b/light_control.py
@@ -135,6 +135,23 @@ def global_action(func):
     sys.exit(0)
 
 
+def _call_no_wait(func, *args, **kwargs):
+    """Call *func* with ``nowait=True`` if supported.
+
+    Some of tinytuya's methods (e.g. ``turn_on``) accept a ``nowait``
+    keyword indicating the call should return immediately without waiting
+    for a response.  When running unit tests the dummy devices don't
+    support this parameter so this helper attempts the call with
+    ``nowait=True`` first and falls back to a plain call if a ``TypeError``
+    is raised.
+    """
+
+    try:
+        func(*args, **dict(kwargs, nowait=True))
+    except TypeError:
+        func(*args, **kwargs)
+
+
 def _find_key(status, keys):
     """Return the first entry in *keys* present in *status*."""
     for key in keys:
@@ -293,7 +310,8 @@ def load_preset(name):
             continue
         dev = get_device(dev_name)
         if 'on' in state:
-            (dev.turn_on if state['on'] else dev.turn_off)()
+            func = dev.turn_on if state['on'] else dev.turn_off
+            _call_no_wait(func)
         if cfg['type'] == 'bulb':
             mode = state.get('mode')
             if mode in ('colour', 'color'):
@@ -301,7 +319,7 @@ def load_preset(name):
                 r, g, b, default_val = _parse_colour_str(colour)
                 if r is not None:
                     print(f"[DEBUG] Loading colour {r,g,b} on {dev_name}")
-                    dev.set_colour(r, g, b)
+                    _call_no_wait(dev.set_colour, r, g, b)
                 if hasattr(dev, 'set_brightness'):
                     if 'value' in state:
                         val = _coerce_level(state['value'])
@@ -311,15 +329,15 @@ def load_preset(name):
                         val = default_val
                     if val is not None:
                         print(f"[DEBUG] Loading brightness {val} on {dev_name}")
-                        dev.set_brightness(val)
+                        _call_no_wait(dev.set_brightness, val)
             else:
                 if 'brightness' in state and hasattr(dev, 'set_brightness'):
                     bright = _coerce_level(state['brightness'])
                     print(f"[DEBUG] Loading brightness {bright} on {dev_name}")
-                    dev.set_brightness(bright)
+                    _call_no_wait(dev.set_brightness, bright)
                 if 'temp' in state:
                     print(f"[DEBUG] Loading colour temperature {state['temp']} on {dev_name}")
-                    dev.set_colourtemp(state['temp'])
+                    _call_no_wait(dev.set_colourtemp, state['temp'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow asynchronous commands with `_call_no_wait`
- send device updates without waiting when loading a preset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a385e86083258a4237d0fc91095c