### PR TITLE
Fix brightness limits

### DIFF
--- a/light_control.py
+++ b/light_control.py
@@ -13,6 +13,9 @@ device_class = {
 # (i.e. sockets) so that only bulbs are modified.
 UPDATE_PLUGS_ON_PRESET_LOAD = True
 
+# Maximum brightness level supported by bulbs
+MAX_BRIGHTNESS = 256
+
 
 def usage():
     print("Usage:")
@@ -22,7 +25,7 @@ def usage():
     print("  python light_control.py <device> s <sat>")
     print("  python light_control.py <device> v <val>")
     print("  python light_control.py <device> temp <kelvin>")
-    print("  python light_control.py <device> bright <0-1000>")
+    print("  python light_control.py <device> bright <0-256>")
     print("  python light_control.py <device> brightenby <delta>")
     print("  python light_control.py <device> dimby <delta>")
     print("  python light_control.py <device> get")
@@ -170,10 +173,10 @@ def current_brightness(device):
 
 
 def adjust_brightness(device, delta):
-    """Adjust *device* brightness by *delta* within 0..1000."""
+    """Adjust *device* brightness by *delta* within 0..256."""
 
     level, mode = current_brightness(device)
-    new_level = max(0, min(1000, level + delta))
+    new_level = max(0, min(MAX_BRIGHTNESS, level + delta))
     device.set_brightness(new_level)
     print(f"[DEBUG] adjust_brightness {level} + {delta} -> {new_level}")
     return new_level, mode

--- a/test_light_control.py
+++ b/test_light_control.py
@@ -260,12 +260,12 @@ def test_load_preset_can_ignore_plugs(tmp_path, monkeypatch):
     assert plug.calls == []
 
 
-def test_brightenby_caps_at_1000():
-    bulb = DummyBulb({'20': True, '21': 'colour', '25': '900'})
+def test_brightenby_caps_at_256():
+    bulb = DummyBulb({'20': True, '21': 'colour', '25': '200'})
 
-    light_control.adjust_brightness(bulb, 200)
+    light_control.adjust_brightness(bulb, 100)
 
-    assert ('brightness', 1000) in bulb.calls
+    assert ('brightness', light_control.MAX_BRIGHTNESS) in bulb.calls
 
 
 def test_dimby_floors_at_0():
@@ -279,6 +279,6 @@ def test_dimby_floors_at_0():
 def test_dimby_uses_bright_value_v2(monkeypatch):
     bulb = DummyBulb({'20': True, '21': 'white', 'bright_value_v2': '800'})
 
-    light_control.adjust_brightness(bulb, -100)
+    light_control.adjust_brightness(bulb, -600)
 
-    assert ('brightness', 700) in bulb.calls
+    assert ('brightness', 200) in bulb.calls


### PR DESCRIPTION
## Summary
- ensure brightness adjustments cap at 256 using new constant
- update tests to expect new brightness range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f816f8f483259a663ade2193e73e